### PR TITLE
Change megalodon.jp error links to one click

### DIFF
--- a/snapshill.py
+++ b/snapshill.py
@@ -189,7 +189,7 @@ class MegalodonJPArchive(NameMixin):
     def __init__(self, url):
         self.url = url
         self.archived = self.archive()
-        self.error_link = "http://megalodon.jp/pc/get_simple/decide?url=" + self.url
+        self.error_link = "http://megalodon.jp/pc/get_simple/decide?url={}".format(self.url)
 
     def archive(self):
         """

--- a/snapshill.py
+++ b/snapshill.py
@@ -189,7 +189,7 @@ class MegalodonJPArchive(NameMixin):
     def __init__(self, url):
         self.url = url
         self.archived = self.archive()
-        self.error_link = "http://megalodon.jp/?url={}".format(self.url)
+        self.error_link = "http://megalodon.jp/pc/get_simple/decide?url=" + self.url
 
     def archive(self):
         """


### PR DESCRIPTION
Right now clicking on the links it generated takes you to this page:

![screenshot](https://i.imgur.com/8mIE4cL.png)

where you need to click on the button for it to start making the archive

If you go to `http://megalodon.jp/pc/get_simple/decide?url=http://www.reddit.com/r/Games/comments/5ub5ig/dota_2_just_surpassed_three_billion_matches_played/ddt7b6q/`

instead of

`http://megalodon.jp/?url=http://www.reddit.com/r/Games/comments/5ub5ig/dota_2_just_surpassed_three_billion_matches_played/ddt7b6q/`

it starts making it right away without needing you to click on anything